### PR TITLE
Remove adding of ppa because nginx 1.14 has bugs and should not be

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,11 +10,6 @@
     name: apt-transport-https
   when: ansible_pkg_mgr == "apt"
 
-- name: Add repos
-  apt_repository:
-    repo: "ppa:nginx/stable"
-  when: ansible_pkg_mgr == "apt"
-
 - name: Install "nginx" package
   apt:
     name: nginx-full


### PR DESCRIPTION
installed on elasticsearch