### PR TITLE
tasks/main.yml: Support PAM authentication

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,3 +33,9 @@
     state: reloaded
     enabled: True
   when: ansible_service_mgr == "systemd" and nginx_reload.changed
+
+- name: Allow www-data to access shadow for PAM
+  user:
+    append: yes
+    groups: shadow
+    name: www-data


### PR DESCRIPTION
To support it, nginx needs to read `/etc/shadow` which is possible
when in group `shadow`.