### PR TITLE
tasks/main.yml: Install nginx.conf before nginx

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,15 +11,15 @@
   apt_repository:
     repo: deb https://nginx.org/packages/mainline/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} nginx
 
-- name: Install nginx package
-  apt:
-    name: "nginx{% if nginx_install_full_package %}-full{% endif %}"
-
 - name: Set nginx config
   template:
     src: templates/nginx.conf.j2
     dest: /etc/nginx/nginx.conf
   register: nginx_reload
+
+- name: Install nginx package
+  apt:
+    name: "nginx{% if nginx_install_full_package %}-full{% endif %}"
 
 - name: Place template PAM nginx file
   template:


### PR DESCRIPTION
When installing nginx, the service is started. For me, this failed
with the default config. Such a failure can be circumvented by
simply installing the desired config first.