### PR TITLE
Use external conf to block IP addresses

### DIFF
--- a/files/deny.conf
+++ b/files/deny.conf
@@ -1,0 +1,8 @@
+# This file is used to gather blocked IP addresses. It should only contain
+# entries of the form:
+#
+#     deny <ip-address>;
+#
+# It's possible to add IP addresses manually. Additionally services like 
+# fail2ban can use this file to add/remove IP addresses dynamically. A reload
+# of nginx is necessary after making changes to this file.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,11 +15,20 @@
   apt:
     name: "nginx{% if nginx_install_full_package %}-full{% endif %}"
 
+- name: Create config file for blocked IP addresses
+  copy:
+    force: false
+    src: deny.conf
+    dest: /etc/nginx/conf.d/deny.conf
+    mode: 0644
+    owner: root
+    group: root
+
 - name: Set nginx config
   template:
     src: templates/nginx.conf.j2
     dest: /etc/nginx/nginx.conf
-    validate: /usr/sbin/nginx -t -c %s
+    validate: grep -v include %s | /usr/sbin/nginx -t -c /dev/stdin # Validate conf without includes
   notify: Enable and start nginx
 
 - name: Place template PAM nginx file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
   template:
     src: templates/nginx.conf.j2
     dest: /etc/nginx/nginx.conf
-    validate: grep -v include %s | /usr/sbin/nginx -t -c /dev/stdin # Validate conf without includes
+    validate: validate: /usr/sbin/nginx -t -c %s
   notify: Enable and start nginx
 
 - name: Place template PAM nginx file

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -35,6 +35,8 @@ events {
 }
 
 http {
+    include conf.d/deny.conf;
+
     sendfile {{ nginx_sendfile -}};
     tcp_nopush {{ nginx_tcp_nopush -}};
     tcp_nodelay {{ nginx_tcp_nodelay -}};

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -35,7 +35,7 @@ events {
 }
 
 http {
-    include conf.d/deny.conf;
+    include /etc/nginx/conf.d/deny.conf;
 
     sendfile {{ nginx_sendfile -}};
     tcp_nopush {{ nginx_tcp_nopush -}};


### PR DESCRIPTION
I've added another external config file to nginx to keep track of blocked IP addresses. This part of the configuration is going to be dynamically changed by e.g. fail2ban and acts similar to a database. So I think it makes sense to keep it seperate from the default nginx.conf.